### PR TITLE
Standardize Makefiles and paths for smoother pipeline execution

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,6 +16,12 @@ all: $(OUT)/report.pdf
 # Generate the final report
 $(OUT)/report.pdf: $(TEMP)/final_dataset.csv src/3-analysis/visualize.R
 	$(MAKE) -C src/3-analysis all
+	
+# Generate the analysis output (new step)
+$(OUT)/analysis_done.txt: $(TEMP)/final_dataset.csv src/analysis/analysis.R
+	R -e "dir.create('$(OUT)', recursive = TRUE)"
+	Rscript src/analysis/analysis.R
+	@echo "Analysis completed successfully." > $(OUT)/analysis_done.txt
 
 # Generate the cleaned dataset
 $(TEMP)/final_dataset.csv: $(DATA)/photos.csv $(DATA)/business.csv src/2-data-preparation/clean.R

--- a/makefile
+++ b/makefile
@@ -1,23 +1,31 @@
-.SILENT:
-.DELETE_ON_ERROR:
-.PHONY: all preview clean help
+MAKE := "$(MAKE)"
 
+.PHONY: all clean
+
+# Directory paths
 DATA := data
 TEMP := gen/temp
 OUT  := gen/output
 
+# Default goal
 .DEFAULT_GOAL := all
+
+# Main build rule
 all: $(OUT)/report.pdf
 
+# Generate the final report
 $(OUT)/report.pdf: $(TEMP)/final_dataset.csv src/3-analysis/visualize.R
 	$(MAKE) -C src/3-analysis all
 
+# Generate the cleaned dataset
 $(TEMP)/final_dataset.csv: $(DATA)/photos.csv $(DATA)/business.csv src/2-data-preparation/clean.R
 	$(MAKE) -C src/2-data-preparation all
 
+# Download raw data
 $(DATA)/photos.csv $(DATA)/business.csv: src/1-raw-data/download.R
 	$(MAKE) -C src/1-raw-data all
 
+# Clean temporary and output files
 clean:
 	R -e "unlink('$(DATA)', recursive = TRUE)"
 	R -e "unlink('gen', recursive = TRUE)"

--- a/src/1-raw-data/download.R
+++ b/src/1-raw-data/download.R
@@ -5,11 +5,13 @@ library(dplyr)
 library(tidyr)
 library(ggplot2)
 
-#make a data folder to store the data sets in for further use
-dir.create("./data")
 
-photos_file <- "./data/photos.csv"
-business_file <- "./data/business.csv"
+# Make sure the gen/data folder exists
+dir.create("./gen/data", recursive = TRUE)
+
+# Define where files will be saved
+photos_file <- "./gen/data/photos.csv"
+business_file <- "./gen/data/business.csv"
 
 # DOWNLOAD DATA
 
@@ -24,4 +26,3 @@ business_url <- "https://drive.google.com/uc?export=download&id=13AZqPcwUro0jwsZ
 
 download.file(photos_url, photos_file)
 download.file(business_url, business_file)
-

--- a/src/1-raw-data/makefile
+++ b/src/1-raw-data/makefile
@@ -1,8 +1,9 @@
-# Stage 1 — download raw data (single run via a stamp)
-.SILENT:
-.DELETE_ON_ERROR:
+# Stage 1 — Download raw data 
 
-DATA := ../../data
+# Ensure compatibility with Windows systems
+MAKE := "$(MAKE)"
+
+DATA := ../../gen/data
 ROOT := $(abspath ../..)
 
 .PHONY: all

--- a/src/1-raw-data/makefile
+++ b/src/1-raw-data/makefile
@@ -15,5 +15,4 @@ $(DATA)/photos.csv $(DATA)/business.csv: $(DATA)/.downloaded
 $(DATA)/.downloaded: download.R
 	R -e "dir.create('$(DATA)', recursive = TRUE)"
 	Rscript -e "setwd('$(ROOT)'); source('src/1-raw-data/download.R')"
-	@touch $@
-
+	Rscript -e "file.create('$(DATA)/.downloaded')"

--- a/src/2-data-preparation/clean.R
+++ b/src/2-data-preparation/clean.R
@@ -7,8 +7,8 @@ library(ggplot2)
 
 # CLEAN DATA
 
-dataset_business <- read.csv("./data/business.csv")
-dataset_photos <- read.csv("./data/photos.csv")
+dataset_business <- read.csv("./gen/data/business.csv")
+dataset_photos <- read.csv("./gen/data/photos.csv")
 
 ## Step 3: Merge dataset_photos and dataset_business using the "business_id"
 
@@ -30,11 +30,11 @@ filtered_merged_dataset <- merged_dataset %>% select(business_id, review_count, 
 # 'menu' -> 'menu'
 
 recategorized_filtered_merged_dataset <- filtered_merged_dataset %>% mutate(label_grouped = case_when(
-    label %in% c("food", "drink") ~ "food_and_drink",
-    label %in% c("inside", "outside") ~ "environment",
-    label == "menu" ~ "menu",
-    TRUE ~ label   # fallback in case there are unexpected values
-  ))
+  label %in% c("food", "drink") ~ "food_and_drink",
+  label %in% c("inside", "outside") ~ "environment",
+  label == "menu" ~ "menu",
+  TRUE ~ label   # fallback in case there are unexpected values
+))
 
 ## Step 6: Count photos per business_id,per category and total
 
@@ -63,4 +63,4 @@ num_removed <- nrow(dataset_draft) - nrow(final_dataset)
 cat("Number of exact duplicate rows removed:", num_removed, "\n")
 
 ## Step 9: Save final data set
-write.csv(final_dataset, "./data/final_dataset.csv", row.names = FALSE)
+write.csv(final_dataset, "gen/temp/final_dataset.csv", row.names = FALSE)

--- a/src/2-data-preparation/makefile
+++ b/src/2-data-preparation/makefile
@@ -1,8 +1,9 @@
-# Stage 2 — clean & aggregate
-.SILENT:
-.DELETE_ON_ERROR:
+# Stage 2 — Clean and aggregate data
 
-DATA := ../../data
+# Ensure compatibility with Windows systems
+MAKE := "$(MAKE)"
+
+DATA := ../../gen/data
 TEMP := ../../gen/temp
 ROOT := $(abspath ../..)
 
@@ -13,8 +14,7 @@ all: $(TEMP)/final_dataset.csv
 $(DATA)/photos.csv $(DATA)/business.csv:
 	$(MAKE) -C ../1-raw-data all
 
+# Create the cleaned and aggregated dataset
 $(TEMP)/final_dataset.csv: clean.R $(DATA)/photos.csv $(DATA)/business.csv
 	R -e "dir.create('$(TEMP)', recursive = TRUE)"
 	Rscript -e "setwd('$(ROOT)'); source('src/2-data-preparation/clean.R')"
-
-

--- a/src/3-analysis/analysis.R
+++ b/src/3-analysis/analysis.R
@@ -7,7 +7,7 @@ library(sandwich)
 library(lmtest)
 
 #load the final data set
-final_dataset <- read.csv("./data/final_dataset.csv")
+final_dataset <- read.csv("gen/temp/final_dataset.csv")
 
 #ASSUMPTION: SKEWNESS
 

--- a/src/3-analysis/analysis.R
+++ b/src/3-analysis/analysis.R
@@ -112,5 +112,3 @@ summary(model_central)
 #When we look at the R-squared, we see that that the total explained variance by our model is very low (around 3.5%). 
 #This means that, although the number of photos and the dominant category have a measurable effect,
 #The vast majority of the variation in star ratings is caused by other factors that were not included in the model.
-
-

--- a/src/3-analysis/makefile
+++ b/src/3-analysis/makefile
@@ -1,16 +1,17 @@
-# Stage 3 — analysis & visualization
-.SILENT:
-.DELETE_ON_ERROR:
+# Stage 3 — Analysis and visualization
+
+# Ensure compatibility with Windows systems
+MAKE := "$(MAKE)"
 
 TEMP := ../../gen/temp
 OUT  := ../../gen/output
 ROOT := $(abspath ../..)
 
 .PHONY: all
-all: $(OUT)/Rplots.pdf
+all: $(OUT)/analysis_done.txt
 
-$(OUT)/Rplots.pdf: visualize.R $(TEMP)/final_dataset.csv
+# Run the existing visualize.R script (no changes needed in the script itself)
+$(OUT)/analysis_done.txt: visualize.R $(TEMP)/final_dataset.csv
 	R -e "dir.create('$(OUT)', recursive = TRUE)"
 	Rscript -e "setwd('$(ROOT)'); source('src/3-analysis/visualize.R')"
-
-
+	@echo "Analysis completed successfully." > $(OUT)/analysis_done.txt

--- a/src/3-analysis/visualize.R
+++ b/src/3-analysis/visualize.R
@@ -7,7 +7,7 @@ library(ggplot2)
 
 # VISUALIZE DATA
 
-final_dataset <- read.csv("./data/final_dataset.csv")
+final_dataset <- read.csv(file.path("gen", "temp", "final_dataset.csv"))
 
 ## Step 10: Analyze suitable plots for data exploration and visualization:
 
@@ -23,11 +23,11 @@ stars_plot <- ggplot(final_dataset, aes(x = total_photos, y = stars)) + geom_poi
 # Plot B: Bar plot showing total photos per category:
 
 photos_per_category_plot <- ggplot(data = data.frame(photo_type = c("Environment", "Food_and_Drink", "Menu"),
-  total = c(
-    sum(final_dataset$environment),
-    sum(final_dataset$food_and_drink),
-    sum(final_dataset$menu)
-  )
+                                                     total = c(
+                                                       sum(final_dataset$environment),
+                                                       sum(final_dataset$food_and_drink),
+                                                       sum(final_dataset$menu)
+                                                     )
 ), aes(x = photo_type, y = total, fill = photo_type)) +
   geom_col() +
   labs(
@@ -37,7 +37,7 @@ photos_per_category_plot <- ggplot(data = data.frame(photo_type = c("Environment
   )
 
 # The output aid us in visualizing the number of photos per category.
-pdf("./reporting/report.pdf")
+pdf("gen/output/report.pdf")
 print(stars_plot)
 print(photos_per_category_plot)
 dev.off()

--- a/team-project-9.Rproj
+++ b/team-project-9.Rproj
@@ -1,0 +1,15 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Makefile


### PR DESCRIPTION
This pull request includes the following updates made with my teammate @asyta-code :
	•	Refactored Makefiles and folder structure for better consistency.
	•	Made all Makefiles work on both Windows and Mac by adding MAKE := "$(MAKE)".
	•	Moved raw data from the main /data folder to /gen/data to keep the root directory clean.
	•	Updated file paths in download.R, clean.R, and Makefiles to match the new structure.
	•	Fixed inconsistent folder references and ensured outputs are saved in /gen/temp and /gen/output.
	•	Removed unnecessary directives and duplicate targets.
	•	Verified that the full pipeline now runs smoothly with a single make command.
